### PR TITLE
fix(resume): pin Next.js to 15.5.15 for Vercel CVE resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.2",
     "lucide-react": "^0.460.0",
-    "next": "^15",
+    "next": "15.5.15",
     "react": "19.0.0-rc-66855b96-20241106",
     "react-dom": "19.0.0-rc-66855b96-20241106",
     "tailwind-merge": "^2.5.4",
@@ -29,7 +29,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^9",
-    "eslint-config-next": "^15",
+    "eslint-config-next": "15.5.15",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"


### PR DESCRIPTION
## Problem

Vercel was resolving \`"next": "^15"\` via npm and deploying \`15.0.3\` from its package cache, still triggering the CVE-2025-66478 block.

## Fix

Explicitly pin \`next\` and \`eslint-config-next\` to \`15.5.15\` — no ambiguity for Vercel's resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)